### PR TITLE
Discover Kafka services across clusters

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4091,6 +4091,7 @@ tableHeaders:
   clusterCreatorDefault: Cluster Creator Default
   clusterFlow: Cluster Flow
   clusterOutput: Cluster Output
+  cluster: Cluster
   clusters: Clusters
   clustersReady: Clusters Ready
   clusterGroups: Cluster Groups
@@ -4180,6 +4181,7 @@ tableHeaders:
   scale: Scale
   scope: Scope
   selector: Selector
+  serviceType: Service type
   simpleName: Name
   simpleScale: Scale
   simpleType: Type

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2156,6 +2156,8 @@ landing:
       lastVisited: Take me to the area I last visited
       custom: "Take me to cluster:"
   welcomeToRancher: 'Welcome to {vendor}'
+  kafkas:
+    title: Available Kafka clusters
 
 logging:
   clusterFlow:

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -198,7 +198,6 @@ export default {
     },
     kafkaHeaders() {
       return [
-        STATE,
         {
           name:          'name',
           labelKey:      'tableHeaders.name',
@@ -207,10 +206,34 @@ export default {
           canBeVariable: true,
         },
         {
-          label: 'Klaster', // TODO: Get label from translations
+          label: this.t('tableHeaders.cluster'),
           value: 'metadata.cluster',
           name:  'Cluster',
           sort:  ['metadata.cluster'],
+        },
+        {
+          label: this.t('tableHeaders.namespace'),
+          value: 'metadata.namespace',
+          name:  'Namespace',
+          sort:  ['metadata.namespace'],
+        },
+        {
+          label: this.t('tableHeaders.serviceType'),
+          value: 'spec.type',
+          name:  'ServiceType',
+          sort:  ['spec.type'],
+        },
+        {
+          label: this.t('tableHeaders.address'),
+          value: 'spec.clusterIP',
+          name:  'ClusterIP',
+          sort:  ['spec.clusterIP'],
+        },
+        {
+          label: this.t('tableHeaders.port'),
+          value: 'spec.ports.1.port', // port type: tcp-clients
+          name:  'Port',
+          sort:  ['spec.ports.1.port'],
         },
 
       ];
@@ -401,7 +424,7 @@ export default {
                     <h2 class="mb-0">
                       Available kafkas
                     </h2>
-                    <BadgeState :label="clusters.length.toString()" color="role-tertiary ml-20 mr-20" />
+                    <BadgeState :label="myKafkas.length.toString()" color="role-tertiary ml-20 mr-20" />
                   </div>
                 </template>
                 <template #header-middle>

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -10,7 +10,7 @@ import SimpleBox from '@/components/SimpleBox';
 import LandingPagePreference from '@/components/LandingPagePreference';
 import SingleClusterInfo from '@/components/SingleClusterInfo';
 import { mapGetters, mapState } from 'vuex';
-import { MANAGEMENT, CAPI } from '@/config/types';
+import { MANAGEMENT, CAPI, KAFKA } from '@/config/types';
 import { NAME as MANAGER } from '@/config/product/manager';
 import { STATE } from '@/config/table-headers';
 import { MODE, _IMPORT } from '@/config/query-params';
@@ -48,6 +48,7 @@ export default {
       type: MANAGEMENT.CLUSTER,
       opt:  { url: MANAGEMENT.CLUSTER }
     });
+    this.kafkas = await this.$store.dispatch('cluster/findAll', { type: KAFKA.SERVICE });
   },
 
   data() {
@@ -66,7 +67,7 @@ export default {
     ];
 
     return {
-      HIDE_HOME_PAGE_CARDS, clusters: [], fullVersion, pageActions, vendor: getVendor(),
+      HIDE_HOME_PAGE_CARDS, clusters: [], kafkas: [], fullVersion, pageActions, vendor: getVendor(),
     };
   },
 
@@ -154,6 +155,24 @@ export default {
         //   name:  'explorer',
         //   label:  this.t('landing.clusters.explorer')
         // }
+      ];
+    },
+    kafkaHeaders() {
+      return [
+        STATE,
+        {
+          name:          'name',
+          labelKey:      'tableHeaders.name',
+          value:         'nameDisplay',
+          sort:          ['nameSort'],
+          canBeVariable: true,
+        },
+        {
+          label: this.t('landing.clusters.provider'),
+          value: 'status.provider',
+          name:  'Provider',
+          sort:  ['status.provider'],
+        },
       ];
     },
 
@@ -334,6 +353,41 @@ export default {
                     {{ t('landing.clusters.explore') }}
                   </button>
                 </template> -->
+              </SortableTable>
+              <br />
+              <SortableTable :table-actions="false" :row-actions="false" key-field="id" :rows="kafkas" :headers="kafkaHeaders">
+                <template #header-left>
+                  <div class="row table-heading">
+                    <h2 class="mb-0">
+                      Available kafkas
+                    </h2>
+                    <BadgeState :label="clusters.length.toString()" color="role-tertiary ml-20 mr-20" />
+                  </div>
+                </template>
+                <template #header-middle>
+                  <n-link
+                    :to="importLocation"
+                    class="btn btn-sm role-primary"
+                  >
+                    {{ t('cluster.importAction') }}
+                  </n-link>
+                  <n-link
+                    :to="createLocation"
+                    class="btn btn-sm role-primary"
+                  >
+                    {{ t('generic.create') }}
+                  </n-link>
+                </template>
+                <template #col:name="{row}">
+                  <td>
+                    <span>
+                      <n-link v-if="row.isReady" :to="{ name: 'c-cluster-explorer', params: { cluster: row.id }}">
+                        {{ row.nameDisplay }}
+                      </n-link>
+                      <span v-else>{{ row.nameDisplay }}</span>
+                    </span>
+                  </td>
+                </template>
               </SortableTable>
             </div>
             <div v-else class="col span-12">

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -422,7 +422,7 @@ export default {
                 <template #header-left>
                   <div class="row table-heading">
                     <h2 class="mb-0">
-                      Available kafkas
+                      {{ t('landing.kafkas.title') }}
                     </h2>
                     <BadgeState :label="myKafkas.length.toString()" color="role-tertiary ml-20 mr-20" />
                   </div>


### PR DESCRIPTION
On main dashboard, display all Kafka services from all connected Kubernetes clusters. This is a step on a way to configure Kafka-dependent services.

Jira ticket: [Implement service discovery across all clusters](https://jira.devtools.intel.com/browse/CSP-5561)